### PR TITLE
Обновление Mapkit в андроид до версии 3.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,13 +32,13 @@ repositories {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-location:16.0.0'
-    implementation ('com.yandex.android:mapkit:3.1.0') {
+    implementation ('com.yandex.android:mapkit:3.2.0') {
         exclude group: "com.google.android.gms"
     }
-    implementation ('com.yandex.android:transport:3.1.0') {
+    implementation ('com.yandex.android:transport:3.2.0') {
         exclude group: "com.google.android.gms"
     }
-    implementation ('com.yandex.android:directions:3.1.0') {
+    implementation ('com.yandex.android:directions:3.2.0') {
         exclude group: "com.google.android.gms"
     }
     implementation 'com.facebook.react:react-native:+'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-yamap",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Yandex.MapKit and Yandex.Geocoder for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Это решает проблему с падением карт - [issue в репозитории с демо](https://github.com/yandex/mapkit-android-demo/issues/49)

Обновление до последней версии (3.5.0) не удается - [issue](https://github.com/yandex/mapkit-android-demo/issues/116)