### PR TITLE
Поддержка версии 4.1.0 Map Kit SDK

### DIFF
--- a/RNYamap.podspec
+++ b/RNYamap.podspec
@@ -8,11 +8,11 @@ Pod::Spec.new do |s|
     s.homepage     = "vvdev.ru"
     s.license      = "MIT"
     s.author       = { package["author"]["name"] => package["author"]["email"] }
-    s.platform     = :ios, "9.0"
+    s.platform     = :ios, "12.0"
     s.source       = { :git => "https://github.com/author/RNYamap.git", :tag => "master" }
     s.source_files = "ios/**/*.{h,m}"
     # s.requires_arc = true
 
     s.dependency "React"
-    s.dependency "YandexMapsMobile", "4.0.0-full"
+    s.dependency "YandexMapsMobile", "4.1.0-full"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,21 +4,17 @@ buildscript {
         jcenter()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
-    }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 21
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }
@@ -32,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:16.0.0'
+    implementation 'com.google.android.gms:play-services-location:20.0.0'
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.yandex.android:maps.mobile:4.0.0-full'
+    implementation 'com.yandex.android:maps.mobile:4.1.0-full'
 }

--- a/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
+++ b/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
@@ -1,7 +1,5 @@
 package ru.vvdev.yamap;
 
-import androidx.annotation.NonNull;
-
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -12,7 +10,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.yandex.mapkit.MapKitFactory;
 import com.yandex.mapkit.transport.TransportFactory;
 import com.yandex.runtime.i18n.I18nManagerFactory;
-import com.yandex.runtime.i18n.LocaleListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -91,12 +88,8 @@ public class RNYamapModule extends ReactContextBaseJavaModule {
         runOnUiThread(new Thread(new Runnable() {
             @Override
             public void run() {
-                I18nManagerFactory.getLocale(new LocaleListener() {
-                    @Override
-                    public void onLocaleReceived(@NonNull String s) {
-                        successCb.invoke(s);
-                    }
-                });
+                String locale = I18nManagerFactory.getLocale();
+                successCb.invoke(locale);
             }
         }));
     }

--- a/android/src/main/java/ru/vvdev/yamap/view/YamapView.java
+++ b/android/src/main/java/ru/vvdev/yamap/view/YamapView.java
@@ -48,7 +48,7 @@ import com.yandex.mapkit.map.VisibleRegion;
 import com.yandex.mapkit.map.MapType;
 import com.yandex.mapkit.mapview.MapView;
 import com.yandex.mapkit.transport.TransportFactory;
-import com.yandex.mapkit.transport.masstransit.MasstransitOptions;
+import com.yandex.mapkit.transport.masstransit.FilterVehicleTypes;
 import com.yandex.mapkit.transport.masstransit.MasstransitRouter;
 import com.yandex.mapkit.transport.masstransit.PedestrianRouter;
 import com.yandex.mapkit.transport.masstransit.Route;
@@ -57,6 +57,7 @@ import com.yandex.mapkit.transport.masstransit.Section;
 import com.yandex.mapkit.transport.masstransit.SectionMetadata;
 import com.yandex.mapkit.transport.masstransit.Session;
 import com.yandex.mapkit.transport.masstransit.TimeOptions;
+import com.yandex.mapkit.transport.masstransit.TransitOptions;
 import com.yandex.mapkit.transport.masstransit.Transport;
 import com.yandex.mapkit.transport.masstransit.Weight;
 import com.yandex.mapkit.user_location.UserLocationLayer;
@@ -267,8 +268,8 @@ public class YamapView extends MapView implements UserLocationObjectListener, Ca
             pedestrianRouter.requestRoutes(_points, new TimeOptions(), listener);
             return;
         }
-        MasstransitOptions masstransitOptions = new MasstransitOptions(new ArrayList<String>(), vehicles, new TimeOptions());
-        masstransitRouter.requestRoutes(_points, masstransitOptions, listener);
+        TransitOptions transitOptions = new TransitOptions(FilterVehicleTypes.NONE.value, new TimeOptions());
+        masstransitRouter.requestRoutes(_points, transitOptions, listener);
     }
 
     public void fitAllMarkers() {
@@ -460,7 +461,7 @@ public class YamapView extends MapView implements UserLocationObjectListener, Ca
         routeMetadata.putInt("routeIndex", routeIndex);
         final WritableArray stops = new WritableNativeArray();
         for (RouteStop stop : section.getStops()) {
-            stops.pushString(stop.getStop().getName());
+            stops.pushString(stop.getMetadata().getStop().getName());
         }
         routeMetadata.putArray("stops", stops);
         if (data.getTransports() != null) {

--- a/ios/RNYamap.m
+++ b/ios/RNYamap.m
@@ -58,9 +58,8 @@ RCT_EXPORT_METHOD(resetLocale:(RCTResponseSenderBlock)successCb errorCallback:(R
 }
 
 RCT_EXPORT_METHOD(getLocale:(RCTResponseSenderBlock)successCb errorCallback:(RCTResponseSenderBlock) errorCb) {
-    [YRTI18nManagerFactory getLocaleWithLocaleDelegate:^(NSString * _Nonnull locale) {
-        successCb(@[locale]);
-    }];
+    NSString * locale = [YRTI18nManagerFactory getLocale];
+    successCb(@[locale]);
 }
 
 RCT_EXPORT_MODULE()

--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -25,7 +25,7 @@
     YMKDrivingRouter* drivingRouter;
     YMKDrivingSession* drivingSession;
     YMKPedestrianRouter *pedestrianRouter;
-    YMKMasstransitOptions *masstransitOptions;
+    YMKTransitOptions *transitOptions;
     YMKMasstransitSessionRouteHandler routeHandler;
     NSMutableArray<UIView*>* _reactSubviews;
     NSMutableArray *routes;
@@ -50,8 +50,7 @@
     masstransitRouter = [[YMKTransport sharedInstance] createMasstransitRouter];
     drivingRouter = [[YMKDirections sharedInstance] createDrivingRouter];
     pedestrianRouter = [[YMKTransport sharedInstance] createPedestrianRouter];
-    masstransitOptions = [YMKMasstransitOptions masstransitOptionsWithAvoidTypes:[[NSArray alloc] init] acceptTypes:[[NSArray alloc] init] timeOptions:[[YMKTimeOptions alloc] init]];
-    acceptVehicleTypes = [[NSMutableArray<NSString *> alloc] init];
+    transitOptions = [YMKTransitOptions transitOptionsWithAvoid:YMKFilterVehicleTypesNone timeOptions:[[YMKTimeOptions alloc] init]];    acceptVehicleTypes = [[NSMutableArray<NSString *> alloc] init];
     routes = [[NSMutableArray alloc] init];
     currentRouteInfo = [[NSMutableArray alloc] init];
     lastKnownRoutePoints = [[NSMutableArray alloc] init];
@@ -136,7 +135,7 @@
     [routeMetadata setObject:routeWeightData forKey:@"routeInfo"];
     [routeMetadata setObject:@(routeIndex) forKey:@"routeIndex"];
     for (YMKMasstransitRouteStop *stop in section.stops) {
-        [stops addObject:stop.stop.name];
+        [stops addObject:stop.metadata.stop.name];
     }
     [routeMetadata setObject:stops forKey:@"stops"];
     if (data.transports != nil) {
@@ -260,8 +259,8 @@
         walkSession = [pedestrianRouter requestRoutesWithPoints:_points timeOptions:[[YMKTimeOptions alloc] init] routeHandler:_routeHandler];
         return;
     }
-    YMKMasstransitOptions* _masstransitOptions =[YMKMasstransitOptions masstransitOptionsWithAvoidTypes:[[NSArray alloc] init] acceptTypes:vehicles timeOptions:[[YMKTimeOptions alloc] init]];
-    masstransitSession = [masstransitRouter requestRoutesWithPoints:_points masstransitOptions:_masstransitOptions routeHandler:_routeHandler];
+    YMKTransitOptions* _transitOptions = [YMKTransitOptions transitOptionsWithAvoid:YMKFilterVehicleTypesNone timeOptions:[[YMKTimeOptions alloc] init]];
+    masstransitSession = [masstransitRouter requestRoutesWithPoints:_points transitOptions:_transitOptions routeHandler:_routeHandler];
 }
 
 - (UIImage*)resolveUIImage:(NSString*) uri {
@@ -397,7 +396,7 @@
             YamapMarkerView* marker = (YamapMarkerView*) view;
             [lastKnownMarkers addObject:marker];
             if (!userClusters) {
-                [clusterCollection removeWithPlacemark:[marker getMapObject]];
+                [clusterCollection removeWithMapObject:[marker getMapObject]];
             } else {
             YMKMapObjectCollection *objects = self.mapWindow.map.mapObjects;
             [objects removeWithMapObject:[marker getMapObject]];
@@ -619,7 +618,7 @@
         YMKMapObjectCollection *objects = self.mapWindow.map.mapObjects;
         YamapMarkerView* marker = (YamapMarkerView*) subview;
         if (userClusters) {
-            [clusterCollection removeWithPlacemark:[marker getMapObject]];
+            [clusterCollection removeWithMapObject:[marker getMapObject]];
         } else {
         [objects removeWithMapObject:[marker getMapObject]];
         }

--- a/ios/View/YamapPolylineView.m
+++ b/ios/View/YamapPolylineView.m
@@ -42,7 +42,7 @@
     if (mapObject != nil) {
         [mapObject setGeometry:polyline];
         [mapObject setZIndex:[zIndex floatValue]];
-        [mapObject setStrokeColor:strokeColor];
+        [mapObject setStrokeColorWithColor:strokeColor];
         [mapObject setStrokeWidth:[strokeWidth floatValue]];
         [mapObject setDashLength:[dashLength floatValue]];
         [mapObject setGapLength:[gapLength floatValue]];

--- a/ios/YamapPolygon.m
+++ b/ios/YamapPolygon.m
@@ -47,7 +47,7 @@ RCT_CUSTOM_VIEW_PROPERTY (points, NSArray<YMKPoint>, YamapPolygonView) {
 RCT_CUSTOM_VIEW_PROPERTY (innerRings, NSArray<NSArray<YMKPoint>>, YamapPolygonView) {
     NSMutableArray* innerRings = [[NSMutableArray alloc] init];
     if (json != nil) {
-        for (int i = 0; i < [json count]; ++i) {
+        for (int i = 0; i < [(NSArray *)json count]; ++i) {
             [innerRings addObject:[RCTConvert Points:[json objectAtIndex:i]]];
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-yamap",
-  "version": "4.0.19",
+  "version": "4.1.0",
   "description": "Yandex.MapKit and Yandex.Geocoder for react-native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Поддержка версии 4.1.0 Map Kit SDK
- сборка и запуск на эмуляторах М1 ([issue](https://github.com/volga-volga/react-native-yamap/issues/139), [issue](https://github.com/volga-volga/react-native-yamap/issues/89))
- сборка с Xcode 13.3+ ([issue](https://github.com/volga-volga/react-native-yamap/issues/98))

Подробнее про новую версию [тут](https://yandex.ru/dev/maps/mapkit/doc/dg/concepts/versions.html)
