### PR TITLE
fix: fixed func param for setRotated method

### DIFF
--- a/android/src/main/java/ru/vvdev/yamap/view/YamapMarker.java
+++ b/android/src/main/java/ru/vvdev/yamap/view/YamapMarker.java
@@ -80,8 +80,8 @@ public class YamapMarker extends ReactViewGroup implements MapObjectTapListener,
         updateMarker();
     }
 
-    public void setRotated(Boolean rotated) {
-        rotated = rotated;
+    public void setRotated(Boolean _rotated) {
+        rotated = _rotated;
         updateMarker();
     }
 


### PR DESCRIPTION
Мне кажется нужно обновить Readme, потому что добавили пропс для маркера rotated и установили его дефолтное значение в " false " из-за чего пока не укажешь ему true то анимация маркеров не работает.
Ну и плюс из-за этой ошибки в фукнции на android даже пропс не помогал.