### PR TITLE
Add `logoPadding` property + additional maintenance work

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,14 @@ type YamapSuggestWithCoords = {
   uri?: string;
 }
 
-type YandexLogo = {
+type YandexLogoPosition = {
   horizontal: 'left' | 'center' | 'right';
   vertical: 'top' | 'bottom';
+}
+
+type YandexLogoPadding = {
+  horizontal?: number;
+  vertical?: number;
 }
 ```
 
@@ -250,7 +255,8 @@ type YandexLogo = {
 | fastTapEnabled | boolean | true | Убрана ли задержка в 300мс при клике/тапе |
 | clusterColor | string | 'red' | Цвет фона метки-кластера |
 | maxFps | number | 60 | Максимальная частота обновления карты |
-| logoPosition | YandexLogo | {} | Позиция логотипа Яндекса на карте |
+| logoPosition | YandexLogoPosition | {} | Позиция логотипа Яндекса на карте |
+| logoPadding | YandexLogoPadding | {} | Отступ логотипа Яндекса на карте |
 | mapType | string | 'vector' | Тип карты |
 | mapStyle | string | {} | Стили карты согласно [документации](https://yandex.ru/dev/maps/mapkit/doc/dg/concepts/style.html) |
 

--- a/RNYamap.podspec
+++ b/RNYamap.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     # s.requires_arc = true
 
     s.dependency "React"
-    s.dependency "YandexMapsMobile", "4.1.0-full"
+    s.dependency "YandexMapsMobile", "4.2.2-full"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 dependencies {
     implementation 'com.google.android.gms:play-services-location:20.0.0'
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.yandex.android:maps.mobile:4.1.0-full'
+    implementation 'com.yandex.android:maps.mobile:4.2.2-full'
 }

--- a/android/src/main/java/ru/vvdev/yamap/ClusteredYamapViewManager.java
+++ b/android/src/main/java/ru/vvdev/yamap/ClusteredYamapViewManager.java
@@ -330,6 +330,13 @@ public class ClusteredYamapViewManager extends ViewGroupManager<ClusteredYamapVi
         }
     }
 
+    @ReactProp(name = "logoPadding")
+    public void setLogoPadding(View view, ReadableMap params) {
+        if (params != null) {
+            castToYaMapView(view).setLogoPadding(params);
+        }
+    }
+
     @Override
     public void addView(ClusteredYamapView parent, View child, int index) {
         parent.addFeature(child, index);

--- a/android/src/main/java/ru/vvdev/yamap/YamapViewManager.java
+++ b/android/src/main/java/ru/vvdev/yamap/YamapViewManager.java
@@ -320,6 +320,13 @@ public class YamapViewManager extends ViewGroupManager<YamapView> {
         }
     }
 
+    @ReactProp(name = "logoPadding")
+    public void setLogoPadding(View view, ReadableMap params) {
+        if (params != null) {
+            castToYaMapView(view).setLogoPadding(params);
+        }
+    }
+
     @Override
     public void addView(YamapView parent, View child, int index) {
         parent.addFeature(child, index);

--- a/android/src/main/java/ru/vvdev/yamap/view/YamapView.java
+++ b/android/src/main/java/ru/vvdev/yamap/view/YamapView.java
@@ -50,6 +50,7 @@ import com.yandex.mapkit.map.VisibleRegion;
 import com.yandex.mapkit.map.MapType;
 import com.yandex.mapkit.mapview.MapView;
 import com.yandex.mapkit.logo.Alignment;
+import com.yandex.mapkit.logo.Padding;
 import com.yandex.mapkit.logo.HorizontalAlignment;
 import com.yandex.mapkit.logo.VerticalAlignment;
 import com.yandex.mapkit.transport.TransportFactory;
@@ -532,6 +533,12 @@ public class YamapView extends MapView implements UserLocationObjectListener, Ca
         }
 
         getMap().getLogo().setAlignment(new Alignment(horizontalAlignment, verticalAlignment));
+    }
+
+    public void setLogoPadding(@Nullable ReadableMap params) {
+        int horizontalPadding = (params.hasKey("horizontal") && !params.isNull("horizontal")) ? params.getInt("horizontal") : 0;
+        int verticalPadding = (params.hasKey("vertical") && !params.isNull("vertical")) ? params.getInt("vertical") : 0;
+        getMap().getLogo().setPadding(new Padding(horizontalPadding, verticalPadding));
     }
 
     public void setMaxFps(float fps) {

--- a/ios/View/RNYMView.h
+++ b/ios/View/RNYMView.h
@@ -50,6 +50,7 @@
 - (void)removeMarkerReactSubview:(UIView *_Nullable)subview;
 - (void)setFollowUser:(BOOL)follow;
 - (void)setLogoPosition:(NSDictionary *_Nullable)logoPosition;
+- (void)setLogoPadding:(NSDictionary *_Nullable)logoPadding;
 
 @end
 

--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -596,6 +596,14 @@
     [self.mapWindow.map.logo setAlignmentWithAlignment:[YMKLogoAlignment alignmentWithHorizontalAlignment:horizontalAlignment verticalAlignment:verticalAlignment]];
 }
 
+- (void)setLogoPadding:(NSDictionary *)logoPadding {
+    NSUInteger *horizontalPadding = [logoPadding valueForKey:@"horizontal"] != nil ? [logoPadding[@"horizontal"] unsignedIntegerValue] : 0;
+    NSUInteger *verticalPadding = [logoPadding valueForKey:@"vertical"] != nil ? [logoPadding[@"vertical"] unsignedIntegerValue] : 0;
+
+    YMKLogoPadding *padding = [YMKLogoPadding paddingWithHorizontalPadding:horizontalPadding verticalPadding:verticalPadding];
+    [self.mapWindow.map.logo setPaddingWithPadding:padding];
+}
+
 // PROPS
 - (void)setUserLocationIcon:(NSString *)iconSource {
     userLocationImage = [self resolveUIImage:iconSource];

--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -597,8 +597,8 @@
 }
 
 - (void)setLogoPadding:(NSDictionary *)logoPadding {
-    NSUInteger *horizontalPadding = [logoPadding valueForKey:@"horizontal"] != nil ? [logoPadding[@"horizontal"] unsignedIntegerValue] : 0;
-    NSUInteger *verticalPadding = [logoPadding valueForKey:@"vertical"] != nil ? [logoPadding[@"vertical"] unsignedIntegerValue] : 0;
+    NSUInteger *horizontalPadding = [logoPadding valueForKey:@"horizontal"] != nil ? [RCTConvert NSUInteger:logoPadding[@"horizontal"]] : 0;
+    NSUInteger *verticalPadding = [logoPadding valueForKey:@"vertical"] != nil ? [RCTConvert NSUInteger:logoPadding[@"vertical"]] : 0;
 
     YMKLogoPadding *padding = [YMKLogoPadding paddingWithHorizontalPadding:horizontalPadding verticalPadding:verticalPadding];
     [self.mapWindow.map.logo setPaddingWithPadding:padding];

--- a/ios/YamapView.m
+++ b/ios/YamapView.m
@@ -165,6 +165,12 @@ RCT_CUSTOM_VIEW_PROPERTY(logoPosition, BOOL, RNYMView) {
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(logoPadding, BOOL, RNYMView) {
+    if (json && view) {
+        [view setLogoPadding:json];
+    }
+}
+
 // REF
 RCT_EXPORT_METHOD(fitAllMarkers:(nonnull NSNumber *)reactTag) {
     [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {

--- a/src/components/ClusteredYamap.tsx
+++ b/src/components/ClusteredYamap.tsx
@@ -26,7 +26,8 @@ import {
   ScreenPoint,
   MapLoaded,
   InitialRegion,
-  YandexLogo
+  YandexLogoPosition,
+  YandexLogoPadding
 } from '../interfaces';
 import { processColorProps } from '../utils';
 import { YaMap } from './Yamap';
@@ -59,7 +60,8 @@ export interface ClusteredYaMapProps<T = any> extends ViewProps {
   initialRegion?: InitialRegion;
   maxFps?: number;
   followUser?: boolean;
-  logoPosition?: YandexLogo;
+  logoPosition?: YandexLogoPosition;
+  logoPadding?: YandexLogoPadding;
 }
 
 const YaMapNativeComponent = requireNativeComponent<Omit<ClusteredYaMapProps, 'clusteredMarkers'> & {clusteredMarkers: Point[]}>('ClusteredYamapView');

--- a/src/components/Yamap.tsx
+++ b/src/components/Yamap.tsx
@@ -25,7 +25,8 @@ import {
   MapType,
   Animation,
   MapLoaded,
-  YandexLogo
+  YandexLogoPosition,
+  YandexLogoPadding
 } from '../interfaces';
 import { processColorProps } from '../utils';
 
@@ -54,7 +55,8 @@ export interface YaMapProps extends ViewProps {
   initialRegion?: InitialRegion;
   maxFps?: number;
   followUser?: boolean;
-  logoPosition?: YandexLogo;
+  logoPosition?: YandexLogoPosition;
+  logoPadding?: YandexLogoPadding;
 }
 
 const YaMapNativeComponent = requireNativeComponent<YaMapProps>('YamapView');

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -88,7 +88,12 @@ export enum Animation {
   LINEAR
 }
 
-export type YandexLogo = {
+export type YandexLogoPosition = {
   horizontal?: 'left' | 'center' | 'right';
   vertical?: 'top' | 'bottom';
+}
+
+export type YandexLogoPadding = {
+  horizontal?: number;
+  vertical?: number;
 }


### PR DESCRIPTION
This PR adds an ability to customize paddings for Yandex.Maps logo within the map view. This is particularly useful for UIs that extend the map edge-to-edge, which currently may cause the logo to overflow to rounded display corners or be placed inside of reserved screen area (notches, navigation bars, etc.).

`YandexMapsMobile` also had to be updated to the latest version (`4.2.2`) for this to work out.