### PR TITLE
Use Vulkan while running on M1 iOS simulator

### DIFF
--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -49,15 +49,13 @@
 }
 
 - (instancetype)init {
-    BOOL vulcanPreferred = NO;
-
 #if TARGET_OS_SIMULATOR
     NXArchInfo *archInfo = NXGetLocalArchInfo();
     NSString *cpuArch = [NSString stringWithUTF8String:archInfo->description];
-    vulcanPreferred = [cpuArch hasPrefix:@"ARM64"];
+    self = [super initWithFrame:CGRectZero vulkanPreferred:[cpuArch hasPrefix:@"ARM64"]];
+#else
+    self = [super initWithFrame:CGRectZero];
 #endif
-
-    self = [super initWithFrame:CGRectZero vulkanPreferred:vulcanPreferred];
 
     _reactSubviews = [[NSMutableArray alloc] init];
     masstransitRouter = [[YMKTransport sharedInstance] createMasstransitRouter];

--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -1,8 +1,7 @@
 #import <React/RCTComponent.h>
 #import <React/UIView+React.h>
-#import <TargetConditionals.h>
 
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
 #import <mach-o/arch.h>
 #endif
 
@@ -52,17 +51,14 @@
 - (instancetype)init {
     BOOL vulcanPreferred = NO;
 
-#if TARGET_IPHONE_SIMULATOR
-    NXArchInfo *info = NXGetLocalArchInfo();
-    NSString *typeOfCpu = [NSString stringWithUTF8String:info->description];
-
-    if ([typeOfCpu hasPrefix:@"arm64"]) {
-        NSLog(@"Using Vulcan for YMKMapView on ARM-based iOS simulator");
-        vulcanPreferred = YES;
-    }
+#if TARGET_OS_SIMULATOR
+    NXArchInfo *archInfo = NXGetLocalArchInfo();
+    NSString *cpuArch = [NSString stringWithUTF8String:archInfo->description];
+    vulcanPreferred = [cpuArch hasPrefix:@"ARM64"];
 #endif
 
-    self = [super initWithFrame:CGRectZero vulcanPreferred:vulcanPreferred];
+    self = [super initWithFrame:CGRectZero vulkanPreferred:vulcanPreferred];
+
     _reactSubviews = [[NSMutableArray alloc] init];
     masstransitRouter = [[YMKTransport sharedInstance] createMasstransitRouter];
     drivingRouter = [[YMKDirections sharedInstance] createDrivingRouter];

--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -1,5 +1,10 @@
 #import <React/RCTComponent.h>
 #import <React/UIView+React.h>
+#import <TargetConditionals.h>
+
+#if TARGET_IPHONE_SIMULATOR
+#import <mach-o/arch.h>
+#endif
 
 #import <MapKit/MapKit.h>
 #import "../Converter/RCTConvert+Yamap.m"
@@ -45,7 +50,19 @@
 }
 
 - (instancetype)init {
-    self = [super init];
+    BOOL vulcanPreferred = NO;
+
+#if TARGET_IPHONE_SIMULATOR
+    NXArchInfo *info = NXGetLocalArchInfo();
+    NSString *typeOfCpu = [NSString stringWithUTF8String:info->description];
+
+    if ([typeOfCpu hasPrefix:@"arm64"]) {
+        NSLog(@"Using Vulcan for YMKMapView on ARM-based iOS simulator");
+        vulcanPreferred = YES;
+    }
+#endif
+
+    self = [super initWithFrame:CGRectZero vulcanPreferred:vulcanPreferred];
     _reactSubviews = [[NSMutableArray alloc] init];
     masstransitRouter = [[YMKTransport sharedInstance] createMasstransitRouter];
     drivingRouter = [[YMKDirections sharedInstance] createDrivingRouter];


### PR DESCRIPTION
MapKit SDK by default uses OpenGL for rendering that iOS simulators running under M1/M2 do not support, which results in huge memory usage and terrible map responsiveness in apps while developing on newer Mac desktops.

This PR introduces a fix that enables Vulkan rendering while compile target is set to an iOS simulator and runs under ARM64 architecture (M1/M2).