### PR TITLE
Add 'reason' to CameraPosition

### DIFF
--- a/RNYamap.podspec
+++ b/RNYamap.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     # s.requires_arc = true
 
     s.dependency "React"
-    s.dependency "YandexMapsMobile", "4.2.2-full"
+    s.dependency "YandexMapsMobile", "4.4.0-full"
 end


### PR DESCRIPTION
This PR reveals 'reason' property of `CameraPostion` interface. It holds value when the map's camera position was changed. The relevant implementations are already present in native files.