### PR TITLE
rounded marker with an image inside it to android

### DIFF
--- a/android/src/main/java/ru/vvdev/yamap/YamapMarkerManager.kt
+++ b/android/src/main/java/ru/vvdev/yamap/YamapMarkerManager.kt
@@ -90,6 +90,11 @@ class YamapMarkerManager internal constructor() : ViewGroupManager<YamapMarker>(
         )
     }
 
+    @ReactProp(name = "similarMarkersCount") //отображение кол-во одинаковых по координатам маркеров в виде текста, не обязательное свойство
+    fun setSimilarMarkersCount(view: View, count: Int?) {
+        castToMarkerView(view).setSimilarMarkersCount(count)
+    }
+
     override fun addView(parent: YamapMarker, child: View, index: Int) {
         parent.addChildView(child, index)
         super.addView(parent, child, index)

--- a/build/components/Marker.d.ts
+++ b/build/components/Marker.d.ts
@@ -15,6 +15,7 @@ export interface MarkerProps {
     };
     visible?: boolean;
     handled?: boolean;
+    similarMarkersCount?: number; //кол-во одинаковых по координатам маркеров
 }
 interface State {
     recreateKey: boolean;


### PR DESCRIPTION
Отображение изображения внутри маркера с белой обводкой(в будущем можно добавить пропс с заменой цвета) на android (2 изображение как стало, 3 - как было).
Если есть несколько одинаковых по координатам маркеров, можно передать в пропс **similarMarkersCount** номер и будет отображение в виде текста.(вычисление кол-ва соответственно со стороны разработчика) (1 изображение)
<img width="440" alt="Снимок экрана 2024-12-10 в 12 17 41" src="https://github.com/user-attachments/assets/06e83d45-e2dc-413f-ad5f-afbeb4922749">
<img width="445" alt="Снимок экрана 2024-12-10 в 12 17 53" src="https://github.com/user-attachments/assets/f9535879-b591-4c59-836a-d401618060e1">
<img width="441" alt="Снимок экрана 2024-12-10 в 12 18 12" src="https://github.com/user-attachments/assets/67a0348e-5234-4801-90e6-f666693434b1">
