### PR TITLE
bump YaMapKit to 4.15.0-full

### DIFF
--- a/RNYamap.podspec
+++ b/RNYamap.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     # s.requires_arc = true
 
     s.dependency "React"
-    s.dependency "YandexMapsMobile", "4.8.0-full"
+    s.dependency "YandexMapsMobile", "4.15.0-full"
 end

--- a/RNYamap.podspec
+++ b/RNYamap.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     # s.requires_arc = true
 
     s.dependency "React"
-    s.dependency "YandexMapsMobile", "4.15.0-full"
+    s.dependency "YandexMapsMobile", "4.19.0-full"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,12 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def GOOGLE_PLAY_SERVICES_LOCATION_VERSION = safeExtGet('playServicesLocationVersion', "+")
+
 android {
 
     defaultConfig {
@@ -31,8 +37,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:+'
-    implementation 'com.facebook.react:react-native:+'
-    implementation 'com.yandex.android:maps.mobile:4.8.0-full'
-    implementation 'androidx.core:core-ktx:1.13.1'
+     implementation 'com.google.android.gms:play-services-location:$GOOGLE_PLAY_SERVICES_LOCATION_VERSION'
+     implementation 'com.facebook.react:react-native:+'
+     implementation 'com.yandex.android:maps.mobile:4.15.0-full'
+     implementation 'androidx.core:core-ktx:1.13.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,8 +37,8 @@ repositories {
 }
 
 dependencies {
-     implementation 'com.google.android.gms:play-services-location:$GOOGLE_PLAY_SERVICES_LOCATION_VERSION'
-     implementation 'com.facebook.react:react-native:+'
-     implementation 'com.yandex.android:maps.mobile:4.15.0-full'
-     implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'com.google.android.gms:play-services-location:$GOOGLE_PLAY_SERVICES_LOCATION_VERSION'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.yandex.android:maps.mobile:4.15.0-full'
+    implementation 'androidx.core:core-ktx:1.13.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,7 @@ def safeExtGet(prop, fallback) {
 def GOOGLE_PLAY_SERVICES_LOCATION_VERSION = safeExtGet('playServicesLocationVersion', "+")
 
 android {
+    namespace = 'ru.vvdev.yamap'
 
     defaultConfig {
         compileSdkVersion 34
@@ -39,6 +40,6 @@ repositories {
 dependencies {
     implementation 'com.google.android.gms:play-services-location:$GOOGLE_PLAY_SERVICES_LOCATION_VERSION'
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.yandex.android:maps.mobile:4.15.0-full'
+    implementation 'com.yandex.android:maps.mobile:4.19.0-full'
     implementation 'androidx.core:core-ktx:1.13.1'
 }

--- a/android/src/main/java/ru/vvdev/yamap/ClusteredYamapViewManager.kt
+++ b/android/src/main/java/ru/vvdev/yamap/ClusteredYamapViewManager.kt
@@ -128,7 +128,7 @@ class ClusteredYamapViewManager internal constructor() : ViewGroupManager<Cluste
             }
 
             "findRoutes" -> if (args != null) {
-                findRoutes(view, args.getArray(0), args.getArray(1), args.getString(2))
+                findRoutes(view, args.getArray(0), args.getArray(1), args.getString(2)!!)
             }
 
             "setZoom" -> if (args != null) {
@@ -152,11 +152,11 @@ class ClusteredYamapViewManager internal constructor() : ViewGroupManager<Cluste
             }
 
             "getScreenPoints" -> if (args != null) {
-                view.emitWorldToScreenPoints(args.getArray(0), args.getString(1))
+                view.emitWorldToScreenPoints(args.getArray(0)!!, args.getString(1))
             }
 
             "getWorldPoints" -> if (args != null) {
-                view.emitScreenToWorldPoints(args.getArray(0), args.getString(1))
+                view.emitScreenToWorldPoints(args.getArray(0)!!, args.getString(1))
             }
 
             else -> throw IllegalArgumentException(
@@ -171,7 +171,7 @@ class ClusteredYamapViewManager internal constructor() : ViewGroupManager<Cluste
 
     @ReactProp(name = "clusteredMarkers")
     fun setClusteredMarkers(view: View, points: ReadableArray) {
-        castToYaMapView(view).setClusteredMarkers(points.toArrayList())
+        castToYaMapView(view).setClusteredMarkers(points.toArrayList().filterNotNull() as ArrayList<Any>)
     }
 
     @ReactProp(name = "clusterColor")
@@ -243,7 +243,7 @@ class ClusteredYamapViewManager internal constructor() : ViewGroupManager<Cluste
             val vehicles = ArrayList<String>()
             if (jsVehicles != null) {
                 for (i in 0 until jsVehicles.size()) {
-                    vehicles.add(jsVehicles.getString(i))
+                    vehicles.add(jsVehicles.getString(i)!!)
                 }
             }
             castToYaMapView(view).findRoutes(points, vehicles, id)

--- a/android/src/main/java/ru/vvdev/yamap/YamapMarkerManager.kt
+++ b/android/src/main/java/ru/vvdev/yamap/YamapMarkerManager.kt
@@ -107,7 +107,7 @@ class YamapMarkerManager internal constructor() : ViewGroupManager<YamapMarker>(
     ) {
         when (commandType) {
             "animatedMoveTo" -> {
-                val markerPoint = args!!.getMap(0)
+                val markerPoint = args!!.getMap(0)!!
                 val moveDuration = args.getInt(1)
                 val lon = markerPoint.getDouble("lon").toFloat()
                 val lat = markerPoint.getDouble("lat").toFloat()

--- a/android/src/main/java/ru/vvdev/yamap/YamapViewManager.kt
+++ b/android/src/main/java/ru/vvdev/yamap/YamapViewManager.kt
@@ -128,7 +128,7 @@ class YamapViewManager internal constructor() : ViewGroupManager<YamapView>() {
             }
 
             "findRoutes" -> if (args != null) {
-                findRoutes(view, args.getArray(0), args.getArray(1), args.getString(2))
+                findRoutes(view, args.getArray(0), args.getArray(1), args.getString(2)!!)
             }
 
             "setZoom" -> if (args != null) {
@@ -152,11 +152,11 @@ class YamapViewManager internal constructor() : ViewGroupManager<YamapView>() {
             }
 
             "getScreenPoints" -> if (args != null) {
-                view.emitWorldToScreenPoints(args.getArray(0), args.getString(1))
+                view.emitWorldToScreenPoints(args.getArray(0)!!, args.getString(1))
             }
 
             "getWorldPoints" -> if (args != null) {
-                view.emitScreenToWorldPoints(args.getArray(0), args.getString(1))
+                view.emitScreenToWorldPoints(args.getArray(0)!!, args.getString(1))
             }
 
             else -> throw IllegalArgumentException(
@@ -237,7 +237,7 @@ class YamapViewManager internal constructor() : ViewGroupManager<YamapView>() {
 
             if (jsVehicles != null) {
                 for (i in 0 until jsVehicles.size()) {
-                    vehicles.add(jsVehicles.getString(i))
+                    vehicles.add(jsVehicles.getString(i)!!)
                 }
             }
 

--- a/android/src/main/java/ru/vvdev/yamap/view/YamapView.kt
+++ b/android/src/main/java/ru/vvdev/yamap/view/YamapView.kt
@@ -225,7 +225,7 @@ open class YamapView(context: Context?) : MapView(context), UserLocationObjectLi
         val screenPoints = Arguments.createArray()
 
         for (i in 0 until worldPoints.size()) {
-            val p = worldPoints.getMap(i)
+            val p = worldPoints.getMap(i)!!
             val worldPoint = Point(p.getDouble("lat"), p.getDouble("lon"))
             val screenPoint = mapWindow.worldToScreen(worldPoint)
             screenPoints.pushMap(screenPointToJSON(screenPoint))
@@ -244,7 +244,7 @@ open class YamapView(context: Context?) : MapView(context), UserLocationObjectLi
         val worldPoints = Arguments.createArray()
 
         for (i in 0 until screenPoints.size()) {
-            val p = screenPoints.getMap(i)
+            val p = screenPoints.getMap(i)!!
             val screenPoint = ScreenPoint(p.getDouble("x").toFloat(), p.getDouble("y").toFloat())
             val worldPoint = mapWindow.screenToWorld(screenPoint)
             worldPoints.pushMap(worldPointToJSON(worldPoint))
@@ -590,10 +590,10 @@ open class YamapView(context: Context?) : MapView(context), UserLocationObjectLi
         if (show) {
             userLocationLayer!!.setObjectListener(this)
             userLocationLayer!!.isVisible = true
-            userLocationLayer!!.isHeadingEnabled = true
+            userLocationLayer!!.isHeadingModeActive = true
         } else {
             userLocationLayer!!.isVisible = false
-            userLocationLayer!!.isHeadingEnabled = false
+            userLocationLayer!!.isHeadingModeActive = false
             userLocationLayer!!.setObjectListener(null)
         }
     }

--- a/android/src/main/java/ru/vvdev/yamap/view/YamapView.kt
+++ b/android/src/main/java/ru/vvdev/yamap/view/YamapView.kt
@@ -84,7 +84,7 @@ open class YamapView(context: Context?) : MapView(context), UserLocationObjectLi
     private var userLocationIconScale = 1f
     private var userLocationBitmap: Bitmap? = null
     private val routeMng = RouteManager()
-    private var routeOptions: RouteOptions = RouteOptions(FitnessOptions(false))
+    private var routeOptions: RouteOptions = RouteOptions(FitnessOptions())
     private val masstransitRouter = TransportFactory.getInstance().createMasstransitRouter()
     private val drivingRouter: DrivingRouter
     private val pedestrianRouter = TransportFactory.getInstance().createPedestrianRouter()
@@ -295,7 +295,7 @@ open class YamapView(context: Context?) : MapView(context), UserLocationObjectLi
             val _points = ArrayList<RequestPoint>()
             for (i in points.indices) {
                 val point = points[i]
-                val _p = RequestPoint(point!!, RequestPointType.WAYPOINT, null, null)
+                val _p = RequestPoint(point!!, RequestPointType.WAYPOINT, null, null, null)
                 _points.add(_p)
             }
 
@@ -310,7 +310,7 @@ open class YamapView(context: Context?) : MapView(context), UserLocationObjectLi
         val _points = ArrayList<RequestPoint>()
         for (i in points.indices) {
             val point = points[i]
-            _points.add(RequestPoint(point!!, RequestPointType.WAYPOINT, null, null))
+            _points.add(RequestPoint(point!!, RequestPointType.WAYPOINT, null, null, null))
         }
         val listener: Session.RouteListener = object : Session.RouteListener {
             override fun onMasstransitRoutes(routes: List<Route>) {

--- a/ios/ClusteredYamapView.m
+++ b/ios/ClusteredYamapView.m
@@ -186,7 +186,7 @@ RCT_EXPORT_METHOD(findRoutes:(nonnull NSNumber*) reactTag json:(NSDictionary*) j
         NSArray<YMKPoint*>* points = [RCTConvert Points:json[@"points"]];
         NSMutableArray<YMKRequestPoint*>* requestPoints = [[NSMutableArray alloc] init];
         for (int i = 0; i < [points count]; ++i) {
-            YMKRequestPoint * requestPoint = [YMKRequestPoint requestPointWithPoint:[points objectAtIndex:i] type: YMKRequestPointTypeWaypoint pointContext:nil drivingArrivalPointId:nil];
+            YMKRequestPoint * requestPoint = [YMKRequestPoint requestPointWithPoint:[points objectAtIndex:i] type: YMKRequestPointTypeWaypoint pointContext:nil drivingArrivalPointId:nil indoorLevelId:nil];
             [requestPoints addObject:requestPoint];
         }
         NSArray<NSString*>* vehicles = [RCTConvert Vehicles:json[@"vehicles"]];

--- a/ios/View/RNYMView.m
+++ b/ios/View/RNYMView.m
@@ -64,7 +64,7 @@
     drivingRouter = [[YMKDirectionsFactory instance] createDrivingRouterWithType:YMKDrivingRouterTypeOnline];
     pedestrianRouter = [[YMKTransportFactory instance] createPedestrianRouter];
     transitOptions = [YMKTransitOptions transitOptionsWithAvoid:YMKFilterVehicleTypesNone timeOptions:[[YMKTimeOptions alloc] init]];    acceptVehicleTypes = [[NSMutableArray<NSString *> alloc] init];
-    routeOptions = [YMKRouteOptions routeOptionsWithFitnessOptions:[YMKFitnessOptions fitnessOptionsWithAvoidSteep:false]];
+    routeOptions = [YMKRouteOptions routeOptionsWithFitnessOptions:[YMKFitnessOptions fitnessOptionsWithAvoidSteep:false avoidStairs:false]];
     routes = [[NSMutableArray alloc] init];
     currentRouteInfo = [[NSMutableArray alloc] init];
     lastKnownRoutePoints = [[NSMutableArray alloc] init];

--- a/ios/YamapSuggests.swift
+++ b/ios/YamapSuggests.swift
@@ -131,7 +131,7 @@ class YamapSuggests: NSObject {
 
         if let userPosition = options["userPosition"] as? [String: Any] {
             do {
-                if let userPoint = try mapPoint(fromDictionary: userPosition, withKey: "userPosition") {
+                if let userPoint = try mapPoint(fromDictionary: options, withKey: "userPosition") {
                     opt.userPosition = userPoint
                 }
             } catch {

--- a/ios/YamapView.m
+++ b/ios/YamapView.m
@@ -212,7 +212,7 @@ RCT_EXPORT_METHOD(findRoutes:(nonnull NSNumber *)reactTag json:(NSDictionary *)j
         NSMutableArray<YMKRequestPoint *> *requestPoints = [[NSMutableArray alloc] init];
 
         for (int i = 0; i < [points count]; ++i) {
-            YMKRequestPoint *requestPoint = [YMKRequestPoint requestPointWithPoint:[points objectAtIndex:i] type:YMKRequestPointTypeWaypoint pointContext:nil drivingArrivalPointId:nil];
+            YMKRequestPoint *requestPoint = [YMKRequestPoint requestPointWithPoint:[points objectAtIndex:i] type:YMKRequestPointTypeWaypoint pointContext:nil drivingArrivalPointId:nil indoorLevelId:nil];
             [requestPoints addObject:requestPoint];
         }
 


### PR DESCRIPTION
**Проблема**
- после обновления на RN0.74.5 появились массовые нативные краши на iOS18.+ 
`yandex::maps::runtime::attestation_storage::availableMethods`
- в [release-notes YaMapKit](https://yandex.ru/maps-api/docs/mapkit/versions.html) увидели версию `4.8.1 - Исправлена утечка памяти на iOS 18`, обновились, изначальный краш пропал но появился новый
`yandex::maps::runtime::platform_dispatcher::internal::runPlatformTask(std::__1::function<void ()>)`
- обновились на версию `4.15.0` (в тот момент была самая актуальная) т.к. в разных версиях были упоминания `Оптимизировано использование оперативной памяти (RAM).`, обновились, все известные нативные краши с якартами полечились

**Решение**
- обновиться на версию `4.15.0`

**Тестирование**
- регрессился базовый функционал карт: рендеринг, перемещение, зум, местоположение, пины, саджесты
- пользовательская аудитория ~1.5млн MAU (2-продукта, 2-платформы iOS/Android)